### PR TITLE
🙋‍♂️ Automate the notarization process with bash script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,3 @@ npm-debug.log
 
 # WebStorm
 .idea
-
-# notarization
-.skpmrc

--- a/.skpmrc
+++ b/.skpmrc
@@ -1,0 +1,3 @@
+notarization:
+    authority: 'Developer ID Application: Frontify AG'
+    command: './notarize.sh' 

--- a/notarize.sh
+++ b/notarize.sh
@@ -17,6 +17,7 @@ if [[ -z "$EMAIL" || -z "$PASSWORD" ]];
 then
     echo "Missing email or password. Use the following command to add the credentials to keychain for future use."
     echo "security add-generic-password -a <email> -w <password> -s AC_PASSWORD"
+    echo "More on this in the wiki: https://weare.frontify.com/document/41#/setup/sketch-plugin/publish-the-plugin"
     exit 1
 fi
 

--- a/notarize.sh
+++ b/notarize.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+ZIP=$1
+
+if [[ -z "$ZIP" ]];
+then
+    echo "Path to zipped plugin not provided."
+    echo "Run: ./notarize.sh ./path/to/frontify.sketchplugin.zip"
+    exit 1
+fi
+
+BUNDLE=frontify.sketchplugin
+EMAIL=$(security find-generic-password -s AC_PASSWORD | grep acct | cut -d '=' -f 2 | sed -e 's/"//g')
+PASSWORD=$(security find-generic-password -s AC_PASSWORD -w)
+
+if [[ -z "$EMAIL" || -z "$PASSWORD" ]];
+then
+    echo "Missing email or password. Use the following command to add the credentials to keychain for future use."
+    echo "security add-generic-password -a <email> -w <password> -s AC_PASSWORD"
+    exit 1
+fi
+
+echo "Notarizing "$ZIP" with the bundle id "$BUNDLE" using the email "$EMAIL" and the password "$PASSWORD
+
+OUTPUT=$(xcrun altool --notarize-app -f $ZIP  --primary-bundle-id $BUNDLE -u $EMAIL -p $PASSWORD)
+
+FIRST_LINE=$(echo "$OUTPUT" | sed -n '1p')
+
+if [[ $FIRST_LINE != "No errors uploading"* ]];
+then
+    echo "Problems with the notarization process. Check the log bellow"
+    echo "$OUTPUT"
+    exit 1
+else
+    SECOND_LINE=$(echo "$OUTPUT" | sed -n '2p')
+    UUID=$(echo $SECOND_LINE| cut -d '=' -f 2)
+
+    echo "Plugin sent to the notarization server. To check the status of the request (might take a few minutes), run:"
+    echo "xcrun altool --notarization-info "$UUID" -u "$EMAIL" -p "$PASSWORD
+fi

--- a/notarize.sh
+++ b/notarize.sh
@@ -21,7 +21,7 @@ then
     exit 1
 fi
 
-echo "Notarizing "$ZIP" with the bundle id "$BUNDLE" using the email "$EMAIL" and the password "$PASSWORD
+echo "Notarizing "$ZIP" with the bundle id "$BUNDLE" using the email "$EMAIL" and the password ******"
 
 OUTPUT=$(xcrun altool --notarize-app -f $ZIP  --primary-bundle-id $BUNDLE -u $EMAIL -p $PASSWORD)
 
@@ -37,5 +37,5 @@ else
     UUID=$(echo $SECOND_LINE| cut -d '=' -f 2)
 
     echo "Plugin sent to the notarization server. To check the status of the request (might take a few minutes), run:"
-    echo "xcrun altool --notarization-info "$UUID" -u "$EMAIL" -p "$PASSWORD
+    echo "xcrun altool --notarization-info "$UUID" -u "$EMAIL" -p ******"
 fi


### PR DESCRIPTION
Skpm added support for plugin notarization when publishing a new version but the CLI fails due some string parsing (no update on the CLI since December last year). An alternative to the internal CLI notarization logic is using custom bash script for firing the notarization command and handling the output.