### PR TITLE
Bug/clearing export folder

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "printWidth": 120,
+    "tabWidth": 4,
+    "singleQuote": true
+}

--- a/src/model/artboard.js
+++ b/src/model/artboard.js
@@ -574,7 +574,9 @@ class Artboard {
                                                                                 )
                                                                                 .then(
                                                                                     function (data) {
-                                                                                        // filemanager.deleteFile(file.path);
+                                                                                        filemanager.deleteFile(
+                                                                                            file.path
+                                                                                        );
                                                                                         this.updateProgress(
                                                                                             artboard,
                                                                                             artboardProgress
@@ -584,7 +586,7 @@ class Artboard {
                                                                                     }.bind(this)
                                                                                 );
                                                                         } else {
-                                                                            // filemanager.deleteFile(file.path);
+                                                                            filemanager.deleteFile(file.path);
                                                                             artboardProgress.setCompletedUnitCount(
                                                                                 artboardProgress.completedUnitCount() +
                                                                                     10

--- a/src/model/artboard.js
+++ b/src/model/artboard.js
@@ -1,11 +1,11 @@
 import fetch from '../helpers/fetch';
 import shaFile from '../helpers/shaFile';
 import writeJSON from '../helpers/writeJSON';
-import sketch from './sketch'
+import sketch from './sketch';
 import target from './target';
 import filemanager from './filemanager';
 import asset from './asset';
-import {isWebviewPresent, sendToWebview} from 'sketch-module-web-view/remote'
+import { isWebviewPresent, sendToWebview } from 'sketch-module-web-view/remote';
 
 let API = require('sketch');
 let DOM = require('sketch/dom');
@@ -20,176 +20,197 @@ class Artboard {
 
     updateProgress(options, progress) {
         if (isWebviewPresent('frontifymain')) {
-            sendToWebview('frontifymain', 'artboardUploadProgress(' + JSON.stringify({
-                id: options.id,
-                id_external: options.id_external,
-                progress: progress.fractionCompleted() * 100
-            }) + ')');
+            sendToWebview(
+                'frontifymain',
+                'artboardUploadProgress(' +
+                    JSON.stringify({
+                        id: options.id,
+                        id_external: options.id_external,
+                        progress: progress.fractionCompleted() * 100,
+                    }) +
+                    ')'
+            );
         }
     }
 
     getArtboards(skipRemote) {
-        return target.getTarget().then(function(target) {
-            let remoteStatus = null;
-            if (skipRemote && this.remoteAssets) {
-                remoteStatus = Promise.resolve({assets: this.remoteAssets});
-            }
-            else {
-                // load remote assets status
-                remoteStatus = fetch('/v1/assets/status/' + target.project.id + '?include_count_annotation=true&include_attachments=true&path=' + encodeURIComponent(target.set.path));
-            }
+        return target.getTarget().then(
+            function (target) {
+                let remoteStatus = null;
+                if (skipRemote && this.remoteAssets) {
+                    remoteStatus = Promise.resolve({ assets: this.remoteAssets });
+                } else {
+                    // load remote assets status
+                    remoteStatus = fetch(
+                        '/v1/assets/status/' +
+                            target.project.id +
+                            '?include_count_annotation=true&include_attachments=true&path=' +
+                            encodeURIComponent(target.set.path)
+                    );
+                }
 
-            return remoteStatus.then(function(result) {
-                let assets = result.assets;
-                this.remoteAssets = result.assets;
+                return remoteStatus.then(
+                    function (result) {
+                        let assets = result.assets;
+                        this.remoteAssets = result.assets;
 
-                // get artboards
-                let artboards = [];
-                let doc = sketch.getDocument();
+                        // get artboards
+                        let artboards = [];
+                        let doc = sketch.getDocument();
 
-                if (doc) {
-                    let mspage = doc.currentPage();
-                    let msartboards = mspage.artboards();
+                        if (doc) {
+                            let mspage = doc.currentPage();
+                            let msartboards = mspage.artboards();
 
-                    for (let i = 0; i < msartboards.length; i++) {
-                        let msartboard = msartboards[i];
+                            for (let i = 0; i < msartboards.length; i++) {
+                                let msartboard = msartboards[i];
 
-                        artboards.push({
-                            id: null,
-                            id_external: '' + msartboard.objectID(),
-                            name: '' + msartboard.name().replace(/\s*\/\s*/g, '/'),
-                            ext: 'png',
-                            sha: null,
-                            state: 'new',
-                            target: '',
-                            modified: null,
-                            modifier_name: null,
-                            modified_localized_ago: null
-                        });
-                    }
+                                artboards.push({
+                                    id: null,
+                                    id_external: '' + msartboard.objectID(),
+                                    name: '' + msartboard.name().replace(/\s*\/\s*/g, '/'),
+                                    ext: 'png',
+                                    sha: null,
+                                    state: 'new',
+                                    target: '',
+                                    modified: null,
+                                    modifier_name: null,
+                                    modified_localized_ago: null,
+                                });
+                            }
 
-                    // compare with remote status
-                    for (let i = 0; i < artboards.length; i++) {
-                        let artboard = artboards[i];
+                            // compare with remote status
+                            for (let i = 0; i < artboards.length; i++) {
+                                let artboard = artboards[i];
 
-                        for (let id in assets) {
-                            if (assets.hasOwnProperty(id)) {
-                                let asset = assets[id];
-                                let path = asset.path;
-                                if (asset.path.indexOf(target.set.path) === 0) {
-                                    path = asset.path.replace(target.set.path, '');
+                                for (let id in assets) {
+                                    if (assets.hasOwnProperty(id)) {
+                                        let asset = assets[id];
+                                        let path = asset.path;
+                                        if (asset.path.indexOf(target.set.path) === 0) {
+                                            path = asset.path.replace(target.set.path, '');
+                                        }
+
+                                        if (path + asset.filename == artboard.name + '.' + asset.ext) {
+                                            artboard.id = asset.id;
+                                            artboard.sha = asset.sha;
+                                            artboard.ext = asset.ext;
+                                            artboard.attachments = asset.attachments;
+                                            artboard.state = 'uploaded';
+                                            artboard.count_annotation_open = asset.count_annotation_open;
+                                            artboard.modified = asset.modified;
+                                            artboard.modifier_name = asset.modifier_name;
+                                            artboard.modified_localized_ago = asset.modified_localized_ago;
+                                        }
+                                    }
                                 }
+                            }
 
-                                if (path + asset.filename == artboard.name + '.' + asset.ext) {
-                                    artboard.id = asset.id;
-                                    artboard.sha = asset.sha;
-                                    artboard.ext = asset.ext;
-                                    artboard.attachments = asset.attachments;
-                                    artboard.state = 'uploaded';
-                                    artboard.count_annotation_open = asset.count_annotation_open;
-                                    artboard.modified = asset.modified;
-                                    artboard.modifier_name = asset.modifier_name;
-                                    artboard.modified_localized_ago = asset.modified_localized_ago;
+                            // compare with selected artboards
+                            let selectedArtboards = [];
+                            let jsdoc = DOM.Document.fromNative(sketch.getDocument());
+                            jsdoc.selectedLayers.forEach(
+                                function (layer) {
+                                    if (layer.type == 'Artboard' || layer.type == 'SymbolMaster') {
+                                        selectedArtboards.push(layer.id);
+                                    }
+                                }.bind(this)
+                            );
+
+                            for (let i = 0; i < artboards.length; i++) {
+                                let artboard = artboards[i];
+                                if (selectedArtboards.indexOf(artboard.id_external) > -1) {
+                                    artboard.selected = true;
                                 }
                             }
                         }
-                    }
 
-                    // compare with selected artboards
-                    let selectedArtboards = [];
-                    let jsdoc = DOM.Document.fromNative(sketch.getDocument());
-                    jsdoc.selectedLayers.forEach(function(layer) {
-                        if (layer.type == 'Artboard' || layer.type == 'SymbolMaster') {
-                            selectedArtboards.push(layer.id);
-                        }
-                    }.bind(this));
+                        let data = {
+                            artboards: artboards.reverse(),
+                            target: target,
+                        };
 
-                    for (let i = 0; i < artboards.length; i++) {
-                        let artboard = artboards[i];
-                        if (selectedArtboards.indexOf(artboard.id_external) > -1) {
-                            artboard.selected = true;
-                        }
-                    }
-                }
-
-                let data = {
-                    artboards: artboards.reverse(),
-                    target: target
-                };
-
-                return data;
-            }.bind(this));
-        }.bind(this));
+                        return data;
+                    }.bind(this)
+                );
+            }.bind(this)
+        );
     }
 
     exportArtboard(artboard, doc) {
-        return new Promise(function(resolve) {
-            let files = [];
-            let predicate = NSPredicate.predicateWithFormat('objectID == %@', artboard.id_external);
-            let msartboard = sketch.findFirstLayer(predicate, nil, MSArtboardGroup, doc);
+        return new Promise(
+            function (resolve) {
+                let files = [];
+                let predicate = NSPredicate.predicateWithFormat('objectID == %@', artboard.id_external);
+                let msartboard = sketch.findFirstLayer(predicate, nil, MSArtboardGroup, doc);
 
-            // Export artboard image -> traditional MSExportRequest for better naming control
-            let imageFormat = MSExportFormat.alloc().init();
-            imageFormat.setFileFormat('png');
-            imageFormat.setScale(this.pixelRatio); // @2x
+                // Export artboard image -> traditional MSExportRequest for better naming control
+                let imageFormat = MSExportFormat.alloc().init();
+                imageFormat.setFileFormat('png');
+                imageFormat.setScale(this.pixelRatio); // @2x
 
-            let path = filemanager.getExportPath() + artboard.name + '.png';
-            let exportRequest = MSExportRequest.exportRequestsFromExportableLayer_exportFormats_useIDForName(msartboard, [imageFormat], true).firstObject();
+                let path = filemanager.getExportPath() + artboard.name + '.png';
+                let exportRequest = MSExportRequest.exportRequestsFromExportableLayer_exportFormats_useIDForName(
+                    msartboard,
+                    [imageFormat],
+                    true
+                ).firstObject();
 
-            doc.saveArtboardOrSlice_toFile(exportRequest, path);
+                doc.saveArtboardOrSlice_toFile(exportRequest, path);
 
-            files.push({
-                name: artboard.name,
-                ext: 'png',
-                id_external: artboard.id_external,
-                id: artboard.id,
-                sha: artboard.sha,
-                path: path,
-                type: 'artboard'
-            });
+                files.push({
+                    name: artboard.name,
+                    ext: 'png',
+                    id_external: artboard.id_external,
+                    id: artboard.id,
+                    sha: artboard.sha,
+                    path: path,
+                    type: 'artboard',
+                });
 
-            // Export artboard structure -> via JS API as its not possible to export JSON with MSExportRequest
-            let jsartboard = DOM.Artboard.fromNative(msartboard);
+                // Export artboard structure -> via JS API as its not possible to export JSON with MSExportRequest
+                let jsartboard = DOM.Artboard.fromNative(msartboard);
 
-            // Export the artboard's data first to preprocess and optimize data
-            let artboardExport = DOM.export(jsartboard, {
-                formats: 'json',
-                output: false
-            });
+                // Export the artboard's data first to preprocess and optimize data
+                let artboardExport = DOM.export(jsartboard, {
+                    formats: 'json',
+                    output: false,
+                });
 
-            // Export formats -> traditional MSExportRequest for better naming control
-            files = files.concat(this.exportFormats(doc, jsartboard));
-            // Save origin info
-            let jsdoc = DOM.Document.fromNative(doc);
+                // Export formats -> traditional MSExportRequest for better naming control
+                files = files.concat(this.exportFormats(doc, jsartboard));
+                // Save origin info
+                let jsdoc = DOM.Document.fromNative(doc);
 
-            this.setLayerSettingForKey(artboardExport, 'meta', {
-                document: {id: jsdoc.id, path: jsdoc.path},
-                page: {id: jsdoc.selectedPage.id, name: jsdoc.selectedPage.name},
-                sketch: {version: '' + API.version.sketch, api: API.version.api }
-                // converting 'sketch.version' to string is needed to not lose it at JSON.stringify
-            });
+                this.setLayerSettingForKey(artboardExport, 'meta', {
+                    document: { id: jsdoc.id, path: jsdoc.path },
+                    page: { id: jsdoc.selectedPage.id, name: jsdoc.selectedPage.name },
+                    sketch: { version: '' + API.version.sketch, api: API.version.api },
+                    // converting 'sketch.version' to string is needed to not lose it at JSON.stringify
+                });
 
-            // Resolve Symbols
-            artboardExport.layers = this.resolveSymbolLayers(artboardExport.layers);
+                // Resolve Symbols
+                artboardExport.layers = this.resolveSymbolLayers(artboardExport.layers);
 
-            // Optimize layers
-            artboardExport.layers = this.optimizeLayers(artboardExport.layers);
+                // Optimize layers
+                artboardExport.layers = this.optimizeLayers(artboardExport.layers);
 
-            const exportName = 'data';
-            const exportPath = filemanager.getExportPath();
-            writeJSON(exportName, artboardExport, exportPath);
+                const exportName = 'data';
+                const exportPath = filemanager.getExportPath();
+                writeJSON(exportName, artboardExport, exportPath);
 
-            files.push({
-                name: exportName,
-                ext: 'json',
-                id_external: artboard.id_external,
-                id: artboard.id,
-                path: exportPath + exportName + '.json',
-                type: 'attachment'
-            });
+                files.push({
+                    name: exportName,
+                    ext: 'json',
+                    id_external: artboard.id_external,
+                    id: artboard.id,
+                    path: exportPath + exportName + '.json',
+                    type: 'attachment',
+                });
 
-            resolve(files);
-        }.bind(this));
+                resolve(files);
+            }.bind(this)
+        );
     }
 
     /***
@@ -200,11 +221,11 @@ class Artboard {
         const data = JSON.stringify(value);
 
         if (!layer.hasOwnProperty('userInfo')) {
-            layer['userInfo'] = {}
+            layer['userInfo'] = {};
         }
 
         if (!layer['userInfo'].hasOwnProperty('com.frontify.sketch')) {
-            settings = layer['userInfo']['com.frontify.sketch'] = {}
+            settings = layer['userInfo']['com.frontify.sketch'] = {};
         }
 
         settings[key] = data;
@@ -216,8 +237,7 @@ class Artboard {
 
             if (layer._class === 'group') {
                 layer.layers = layer.layers.map(optimize);
-            }
-            else if (layer._class === 'bitmap') {
+            } else if (layer._class === 'bitmap') {
                 layer = this.layerReplaceImageData(layer);
             }
 
@@ -242,7 +262,7 @@ class Artboard {
                 let fill = layer.style.fills[index];
 
                 if (fill.fillType === 4 && fill.image) {
-                    layer.style.fills.splice(index,1);
+                    layer.style.fills.splice(index, 1);
                 }
             }
         }
@@ -256,9 +276,9 @@ class Artboard {
      * @returns {{image}|*}
      */
     layerReplaceImageData(layer) {
-
         if (layer.image && layer.image.data && layer.image.data._data) {
-            layer.image.data._data = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+            layer.image.data._data =
+                'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
         }
 
         return layer;
@@ -266,7 +286,6 @@ class Artboard {
 
     resolveSymbolLayers(layers) {
         const resolve = (layer) => {
-
             if (layer._class === 'symbolInstance') {
                 return this.getDetachedGroupByExportedSymbolLayer(layer);
             }
@@ -302,7 +321,7 @@ class Artboard {
         // Get data of the symbolInstance duplicate
         const detachedGroupExport = DOM.export(detachedGroup, {
             formats: 'json',
-            output: false
+            output: false,
         });
 
         // Reset original name
@@ -325,15 +344,14 @@ class Artboard {
      * @returns {void | *}
      */
 
-    recursivelyDetachSymbols (layer) {
+    recursivelyDetachSymbols(layer) {
         if (layer.type === 'Group') {
             layer.layers.forEach((layer) => {
                 this.recursivelyDetachSymbols(layer);
             });
 
             return;
-        }
-        else if(layer.type !== 'SymbolInstance') {
+        } else if (layer.type !== 'SymbolInstance') {
             /* if it's not a symbol, there's nothing to do */
             return;
         }
@@ -350,14 +368,14 @@ class Artboard {
             symbolMaster: {
                 id: originalSymbolMaster.id,
                 symbolId: originalSymbolMaster.symbolId,
-                library: originalSymbolMaster.getLibrary()
-            }
+                library: originalSymbolMaster.getLibrary(),
+            },
         };
 
         /* add meta info to symbolInstance before detaching it */
         Settings.setLayerSettingForKey(layer, 'meta', meta);
 
-        let detachedlayer = layer.detach({recursively: false});
+        let detachedlayer = layer.detach({ recursively: false });
 
         /* detached layer is a now a group, so do detaching for its layers again */
         this.recursivelyDetachSymbols(detachedlayer);
@@ -369,7 +387,6 @@ class Artboard {
         let files = [];
 
         layer.exportFormats.forEach((format) => {
-
             let name = '';
             if (format.prefix && format.prefix !== 'null') {
                 name += format.prefix;
@@ -389,7 +406,11 @@ class Artboard {
             layerFormat.setFileFormat(format.fileFormat);
             layerFormat.setScale(layerSizeAsScaleNumber);
 
-            const exportRequest = MSExportRequest.exportRequestsFromExportableLayer_exportFormats_useIDForName(layer.sketchObject, [layerFormat], true).firstObject();
+            const exportRequest = MSExportRequest.exportRequestsFromExportableLayer_exportFormats_useIDForName(
+                layer.sketchObject,
+                [layerFormat],
+                true
+            ).firstObject();
             doc.saveArtboardOrSlice_toFile(exportRequest, path);
 
             files.push({
@@ -399,7 +420,7 @@ class Artboard {
                 id: layer.id,
                 path: path,
                 type: 'attachment',
-                pixel_ratio: format.size
+                pixel_ratio: format.size,
             });
         });
 
@@ -416,153 +437,253 @@ class Artboard {
         // sequence artboard export and upload
         this.uploadInProgress = true;
 
-        return this.getArtboards().then(function(data) {
-            let target = data.target;
+        return this.getArtboards()
+            .then(
+                function (data) {
+                    let target = data.target;
 
-            // get the current state of the given artboards
-            artboards = artboards.map(function(artboard) {
-                return data.artboards.find(function(remoteArtboard) {
-                    return remoteArtboard.id_external == artboard.id_external;
-                }.bind(this));
-            }.bind(this));
+                    // get the current state of the given artboards
+                    artboards = artboards.map(
+                        function (artboard) {
+                            return data.artboards.find(
+                                function (remoteArtboard) {
+                                    return remoteArtboard.id_external == artboard.id_external;
+                                }.bind(this)
+                            );
+                        }.bind(this)
+                    );
 
-            let doc = sketch.getDocument();
-            if (!doc) {
-                throw new Error('No document found');
-            }
-            else {
-                return artboards.reduce(function(sequence, artboard) {
-                    return sequence.then(function() {
-                        return this.exportArtboard(artboard, doc);
-                    }.bind(this)).then(function(files) {
-                        var artboardProgress = NSProgress.progressWithTotalUnitCount(10 * files.length + 20);
-                        artboardProgress.setCompletedUnitCount(0);
+                    let doc = sketch.getDocument();
+                    if (!doc) {
+                        throw new Error('No document found');
+                    } else {
+                        return artboards.reduce(
+                            function (sequence, artboard) {
+                                return sequence
+                                    .then(
+                                        function () {
+                                            return this.exportArtboard(artboard, doc);
+                                        }.bind(this)
+                                    )
+                                    .then(
+                                        function (files) {
+                                            var artboardProgress = NSProgress.progressWithTotalUnitCount(
+                                                10 * files.length + 20
+                                            );
+                                            artboardProgress.setCompletedUnitCount(0);
 
-                        var polling = setInterval(function() {
-                            this.updateProgress(artboard, artboardProgress);
-                        }.bind(this), 100);
+                                            var polling = setInterval(
+                                                function () {
+                                                    this.updateProgress(artboard, artboardProgress);
+                                                }.bind(this),
+                                                100
+                                            );
 
-                        let artboardChanged = false;
-                        return files.reduce(function(uploadsequence, file) {
-                            return uploadsequence.then(function(assetId) {
-                                if (file.type === 'artboard') {
-                                    if (artboard.sha != shaFile(file.path)) {
-                                        artboardChanged = true;
-                                        return filemanager.uploadFile({
-                                            path: file.path,
-                                            filename: file.name + '.' + file.ext,
-                                            name: file.name,
-                                            id: file.id,
-                                            id_external: file.id_external,
-                                            pixel_ratio: this.pixelRatio,
-                                            folder: target.set.path,
-                                            project: target.project.id,
-                                            type: file.type
-                                        }, artboardProgress).then(function(data) {
-                                            filemanager.deleteFile(file.path);
-                                            this.updateProgress(artboard, artboardProgress);
-                                            artboard.sha = data.sha;
-                                            artboard.id = data.id;
-                                            artboard.nochanges = false;
+                                            let artboardChanged = false;
+                                            return files
+                                                .reduce(
+                                                    function (uploadsequence, file) {
+                                                        return uploadsequence
+                                                            .then(
+                                                                function (assetId) {
+                                                                    if (file.type === 'artboard') {
+                                                                        if (artboard.sha != shaFile(file.path)) {
+                                                                            artboardChanged = true;
+                                                                            return filemanager
+                                                                                .uploadFile(
+                                                                                    {
+                                                                                        path: file.path,
+                                                                                        filename:
+                                                                                            file.name + '.' + file.ext,
+                                                                                        name: file.name,
+                                                                                        id: file.id,
+                                                                                        id_external: file.id_external,
+                                                                                        pixel_ratio: this.pixelRatio,
+                                                                                        folder: target.set.path,
+                                                                                        project: target.project.id,
+                                                                                        type: file.type,
+                                                                                    },
+                                                                                    artboardProgress
+                                                                                )
+                                                                                .then(
+                                                                                    function (data) {
+                                                                                        filemanager.deleteFile(
+                                                                                            file.path
+                                                                                        );
+                                                                                        this.updateProgress(
+                                                                                            artboard,
+                                                                                            artboardProgress
+                                                                                        );
+                                                                                        artboard.sha = data.sha;
+                                                                                        artboard.id = data.id;
+                                                                                        artboard.nochanges = false;
 
-                                            return data.id;
-                                        }.bind(this));
-                                    }
-                                    else {
-                                        artboardChanged = false;
-                                        artboardProgress.setCompletedUnitCount(artboardProgress.completedUnitCount() + 10);
-                                        this.updateProgress(artboard, artboardProgress);
-                                        filemanager.deleteFile(file.path);
-                                        artboard.nochanges = true;
-                                        return artboard.id;
-                                    }
-                                }
-                                else if (file.type === 'attachment') {
-                                    let status = this.getRemoteStatusForAttachment(artboard, file);
+                                                                                        return data.id;
+                                                                                    }.bind(this)
+                                                                                );
+                                                                        } else {
+                                                                            artboardChanged = false;
+                                                                            artboardProgress.setCompletedUnitCount(
+                                                                                artboardProgress.completedUnitCount() +
+                                                                                    10
+                                                                            );
+                                                                            this.updateProgress(
+                                                                                artboard,
+                                                                                artboardProgress
+                                                                            );
+                                                                            filemanager.deleteFile(file.path);
+                                                                            artboard.nochanges = true;
+                                                                            return artboard.id;
+                                                                        }
+                                                                    } else if (file.type === 'attachment') {
+                                                                        let status = this.getRemoteStatusForAttachment(
+                                                                            artboard,
+                                                                            file
+                                                                        );
 
-                                    if (artboardChanged || status.sha != shaFile(file.path)) {
-                                        let filename;
+                                                                        if (
+                                                                            artboardChanged ||
+                                                                            status.sha != shaFile(file.path)
+                                                                        ) {
+                                                                            let filename;
 
-                                        if (file.ext === 'json') {
-                                            filename = file.name + '.' + file.ext;
-                                        }
-                                        else {
-                                            // Generate unique filenames for exportables. That prevents same named layers to overwrite each others exportables.
-                                            filename = file.id_external + '-' + file.pixel_ratio + '.' + file.ext;
-                                        }
+                                                                            if (file.ext === 'json') {
+                                                                                filename = file.name + '.' + file.ext;
+                                                                            } else {
+                                                                                // Generate unique filenames for exportables. That prevents same named layers to overwrite each others exportables.
+                                                                                filename =
+                                                                                    file.id_external +
+                                                                                    '-' +
+                                                                                    file.pixel_ratio +
+                                                                                    '.' +
+                                                                                    file.ext;
+                                                                            }
 
-                                        return filemanager.uploadFile({
-                                            path: file.path,
-                                            filename: filename,
-                                            name: file.name,
-                                            id_external: file.id_external,
-                                            type: file.type,
-                                            asset_id: assetId,
-                                            pixel_ratio: file.pixel_ratio
-                                        }, artboardProgress).then(function(data) {
-                                            // filemanager.deleteFile(file.path);
-                                            this.updateProgress(artboard, artboardProgress);
-                                            status.sha = data.sha;
-                                            return assetId;
-                                        }.bind(this));
-                                    }
-                                    else {
-                                        // filemanager.deleteFile(file.path);
-                                        artboardProgress.setCompletedUnitCount(artboardProgress.completedUnitCount() + 10);
-                                        this.updateProgress(artboard, artboardProgress);
-                                        return assetId;
-                                    }
-                                }
-                            }.bind(this)).catch(function(err) {
-                                console.error(err);
-                                throw err;
-                            }.bind(this));
-                        }.bind(this), Promise.resolve()).then(function(assetId) {
-                            // start import of asset
-                            asset.import(assetId); /* calls the import API */
-                            artboardProgress.setCompletedUnitCount(artboardProgress.completedUnitCount() + 20);
-                            this.updateProgress(artboard, artboardProgress);
-                        }.bind(this)).then(function(data) {
-                            clearInterval(polling);
-                            if (isWebviewPresent('frontifymain')) {
-                                sendToWebview('frontifymain', 'artboardUploaded(' + JSON.stringify(artboard) + ')');
-                            }
-                            return true;
-                        }.bind(this)).catch(function(err) {
-                            clearInterval(polling);
-                            if (isWebviewPresent('frontifymain')) {
-                                sendToWebview('frontifymain', 'artboardUploadFailed(' + JSON.stringify(artboard) + ')');
-                            }
-                            throw err;
-                        }.bind(this));
-                    }.bind(this)).catch(function(err) {
-                        console.error(err);
-                        throw err;
-                    }.bind(this));
-                }.bind(this), Promise.resolve());
-            }
-        }.bind(this)).then(function(data) {
-            this.uploadInProgress = false;
-        }.bind(this)).catch(function(err) {
-            this.uploadInProgress = false;
-            console.error(err);
-        }.bind(this));
+                                                                            return filemanager
+                                                                                .uploadFile(
+                                                                                    {
+                                                                                        path: file.path,
+                                                                                        filename: filename,
+                                                                                        name: file.name,
+                                                                                        id_external: file.id_external,
+                                                                                        type: file.type,
+                                                                                        asset_id: assetId,
+                                                                                        pixel_ratio: file.pixel_ratio,
+                                                                                    },
+                                                                                    artboardProgress
+                                                                                )
+                                                                                .then(
+                                                                                    function (data) {
+                                                                                        // filemanager.deleteFile(file.path);
+                                                                                        this.updateProgress(
+                                                                                            artboard,
+                                                                                            artboardProgress
+                                                                                        );
+                                                                                        status.sha = data.sha;
+                                                                                        return assetId;
+                                                                                    }.bind(this)
+                                                                                );
+                                                                        } else {
+                                                                            // filemanager.deleteFile(file.path);
+                                                                            artboardProgress.setCompletedUnitCount(
+                                                                                artboardProgress.completedUnitCount() +
+                                                                                    10
+                                                                            );
+                                                                            this.updateProgress(
+                                                                                artboard,
+                                                                                artboardProgress
+                                                                            );
+                                                                            return assetId;
+                                                                        }
+                                                                    }
+                                                                }.bind(this)
+                                                            )
+                                                            .catch(
+                                                                function (err) {
+                                                                    console.error(err);
+                                                                    throw err;
+                                                                }.bind(this)
+                                                            );
+                                                    }.bind(this),
+                                                    Promise.resolve()
+                                                )
+                                                .then(
+                                                    function (assetId) {
+                                                        // start import of asset
+                                                        asset.import(assetId); /* calls the import API */
+                                                        artboardProgress.setCompletedUnitCount(
+                                                            artboardProgress.completedUnitCount() + 20
+                                                        );
+                                                        this.updateProgress(artboard, artboardProgress);
+                                                    }.bind(this)
+                                                )
+                                                .then(
+                                                    function (data) {
+                                                        clearInterval(polling);
+                                                        if (isWebviewPresent('frontifymain')) {
+                                                            sendToWebview(
+                                                                'frontifymain',
+                                                                'artboardUploaded(' + JSON.stringify(artboard) + ')'
+                                                            );
+                                                        }
+                                                        return true;
+                                                    }.bind(this)
+                                                )
+                                                .catch(
+                                                    function (err) {
+                                                        clearInterval(polling);
+                                                        if (isWebviewPresent('frontifymain')) {
+                                                            sendToWebview(
+                                                                'frontifymain',
+                                                                'artboardUploadFailed(' + JSON.stringify(artboard) + ')'
+                                                            );
+                                                        }
+                                                        throw err;
+                                                    }.bind(this)
+                                                );
+                                        }.bind(this)
+                                    )
+                                    .catch(
+                                        function (err) {
+                                            console.error(err);
+                                            throw err;
+                                        }.bind(this)
+                                    );
+                            }.bind(this),
+                            Promise.resolve()
+                        );
+                    }
+                }.bind(this)
+            )
+            .then(
+                function (data) {
+                    this.uploadInProgress = false;
+                }.bind(this)
+            )
+            .catch(
+                function (err) {
+                    this.uploadInProgress = false;
+                    console.error(err);
+                }.bind(this)
+            );
     }
 
     getRemoteStatusForAttachment(artboard, file) {
         let status = null;
 
         if (artboard.attachments && artboard.attachments.length > 0) {
-            artboard.attachments.forEach(function(attachment) {
-                if (file.name == attachment.name && file.ext == attachment.ext) {
-                    status = attachment
-                }
-            }.bind(this));
+            artboard.attachments.forEach(
+                function (attachment) {
+                    if (file.name == attachment.name && file.ext == attachment.ext) {
+                        status = attachment;
+                    }
+                }.bind(this)
+            );
         }
 
         if (!status) {
             status = {
-                sha: null
+                sha: null,
             };
         }
 
@@ -571,15 +692,20 @@ class Artboard {
 
     showArtboards(skipRemote) {
         if (!this.uploadInProgress) {
-            this.getArtboards(skipRemote).then(function(data) {
-                if (isWebviewPresent('frontifymain')) {
-                    sendToWebview('frontifymain', 'showArtboards(' + JSON.stringify(data) + ')');
-                }
-            }.bind(this)).catch(function(e) {
-                console.error(e);
-            }.bind(this));
-        }
-        else {
+            this.getArtboards(skipRemote)
+                .then(
+                    function (data) {
+                        if (isWebviewPresent('frontifymain')) {
+                            sendToWebview('frontifymain', 'showArtboards(' + JSON.stringify(data) + ')');
+                        }
+                    }.bind(this)
+                )
+                .catch(
+                    function (e) {
+                        console.error(e);
+                    }.bind(this)
+                );
+        } else {
             console.log('upload in progress');
         }
     }
@@ -594,15 +720,13 @@ class Artboard {
 
         if (sizeString.indexOf('x') !== -1) {
             scale = parseFloat(sizeString);
-        }
-        else if (sizeString.indexOf('w') !== -1) {
+        } else if (sizeString.indexOf('w') !== -1) {
             const widthInPx = parseInt(sizeString);
-            scale = 1 / layerFrame.width * widthInPx;
-        }
-        else if (sizeString.indexOf('h') !== -1) {
+            scale = (1 / layerFrame.width) * widthInPx;
+        } else if (sizeString.indexOf('h') !== -1) {
             // there is a given height
             const heightInPx = parseInt(sizeString);
-            scale = 1 / layerFrame.height * heightInPx;
+            scale = (1 / layerFrame.height) * heightInPx;
         }
 
         return scale;
@@ -610,4 +734,3 @@ class Artboard {
 }
 
 export default new Artboard();
-

--- a/src/model/filemanager.js
+++ b/src/model/filemanager.js
@@ -12,7 +12,6 @@ import response from '../helpers/response';
 class FileManager {
     constructor() {
         this.exportPath = NSTemporaryDirectory() + 'sketch-frontify/';
-        this.clearExportFolder();
     }
 
     getExportPath() {

--- a/src/model/filemanager.js
+++ b/src/model/filemanager.js
@@ -1,13 +1,13 @@
-import readJSON from '../helpers/readJSON'
-import writeJSON from '../helpers/writeJSON'
-import fetch from '../helpers/fetch'
-import createFolder from '../helpers/createFolder'
-import target from './target'
-import sketch from './sketch'
+import readJSON from '../helpers/readJSON';
+import writeJSON from '../helpers/writeJSON';
+import fetch from '../helpers/fetch';
+import createFolder from '../helpers/createFolder';
+import target from './target';
+import sketch from './sketch';
 import FormData from 'sketch-polyfill-fetch/lib/form-data';
-import { isWebviewPresent, sendToWebview } from 'sketch-module-web-view/remote'
-import extend from "../helpers/extend";
-import response from  "../helpers/response";
+import { isWebviewPresent, sendToWebview } from 'sketch-module-web-view/remote';
+import extend from '../helpers/extend';
+import response from '../helpers/response';
 
 class FileManager {
     constructor() {
@@ -24,58 +24,65 @@ class FileManager {
     }
 
     saveCurrent() {
-        return target.getTarget('sources').then(function(data) {
-            // create folder first
-            if (createFolder(data.path)) {
-                let dialog = NSSavePanel.savePanel();
-                dialog.canCreateDirectories = false;
-                dialog.directoryURL = NSURL.fileURLWithPath(data.path);
-                dialog.allowedFileTypes = ['sketch'];
-                dialog.message = 'Save your Sketch File in the Frontify sync folder';
+        return target.getTarget('sources').then(
+            function (data) {
+                // create folder first
+                if (createFolder(data.path)) {
+                    let dialog = NSSavePanel.savePanel();
+                    dialog.canCreateDirectories = false;
+                    dialog.directoryURL = NSURL.fileURLWithPath(data.path);
+                    dialog.allowedFileTypes = ['sketch'];
+                    dialog.message = 'Save your Sketch File in the Frontify sync folder';
 
-                let clicked = dialog.runModal();
+                    let clicked = dialog.runModal();
 
-                if (clicked == NSOKButton) {
-                    let url = dialog.URL();
+                    if (clicked == NSOKButton) {
+                        let url = dialog.URL();
+                        let doc = sketch.getDocument();
+
+                        if (doc) {
+                            doc.saveToURL_ofType_forSaveOperation_error_(
+                                url,
+                                'com.bohemiancoding.sketch.drawing',
+                                NSSaveOperation,
+                                null
+                            );
+                        }
+
+                        return true;
+                    } else {
+                        return false;
+                    }
+                }
+
+                return false;
+            }.bind(this)
+        );
+    }
+
+    moveCurrent() {
+        return target.getTarget('sources').then(
+            function (data) {
+                if (createFolder(data.path)) {
                     let doc = sketch.getDocument();
 
                     if (doc) {
-                        doc.saveToURL_ofType_forSaveOperation_error_(url, "com.bohemiancoding.sketch.drawing", NSSaveOperation, null);
+                        let nsurl = doc.fileURL();
+                        let path = nsurl.path();
+                        let parts = path.split('/');
+                        let currentFilename = parts.pop();
+                        let newNsurl = NSURL.fileURLWithPath(data.path + currentFilename);
+
+                        // move to the target folder
+                        doc.moveToURL_completionHandler_(newNsurl, null);
                     }
 
                     return true;
                 }
-                else {
-                    return false;
-                }
-            }
 
-            return false;
-        }.bind(this));
-
-    }
-
-    moveCurrent() {
-        return target.getTarget('sources').then(function(data) {
-            if (createFolder(data.path)) {
-                let doc = sketch.getDocument();
-
-                if (doc) {
-                    let nsurl = doc.fileURL();
-                    let path = nsurl.path();
-                    let parts = path.split('/');
-                    let currentFilename = parts.pop();
-                    let newNsurl = NSURL.fileURLWithPath(data.path + currentFilename);
-
-                    // move to the target folder
-                    doc.moveToURL_completionHandler_(newNsurl, null);
-                }
-
-                return true;
-            }
-
-            return false;
-        }.bind(this));
+                return false;
+            }.bind(this)
+        );
     }
 
     updateAssetStatus(project, asset) {
@@ -113,7 +120,7 @@ class FileManager {
             name: name,
             filename: filename,
             origin: 'SKETCH',
-            id_external: info.id_external
+            id_external: info.id_external,
         };
 
         if (info.pixel_ratio) {
@@ -125,9 +132,8 @@ class FileManager {
         if (info.type === 'attachment') {
             data['mimetype'] = 'image/png';
             data['asset_id'] = info.asset_id;
-            uri += '/v1/attachment/create'
-        }
-        else if(info.type === 'source') {
+            uri += '/v1/attachment/create';
+        } else if (info.type === 'source') {
             let path = filenameParts.join('/');
             data['mimetype'] = 'application/octet-stream';
             data['id'] = info.id;
@@ -138,8 +144,7 @@ class FileManager {
             if (info.id) {
                 uri += info.id;
             }
-        }
-        else {
+        } else {
             let path = filenameParts.join('/');
             data['mimetype'] = 'image/png';
             data['id'] = info.id;
@@ -157,7 +162,7 @@ class FileManager {
             filepath: info.path,
             type: info.type,
             id: info.id,
-            body: data
+            body: data,
         };
 
         // get token
@@ -165,14 +170,14 @@ class FileManager {
         let defaults = {
             method: 'GET',
             headers: {
-                'Authorization': 'Bearer ' + token.access_token,
-            }
+                Authorization: 'Bearer ' + token.access_token,
+            },
         };
 
         options = extend({}, defaults, options);
 
         if (!uri) {
-            return Promise.reject("Missing URL");
+            return Promise.reject('Missing URL');
         }
 
         uri = token.domain + uri;
@@ -184,12 +189,12 @@ class FileManager {
             coscript.shouldKeepAround = true;
         }
 
-        return new Promise(function(resolve, reject) {
+        return new Promise(function (resolve, reject) {
             var url = NSURL.alloc().initWithString(uri);
             var request = NSMutableURLRequest.requestWithURL(url);
-            request.setHTTPMethod("POST");
+            request.setHTTPMethod('POST');
 
-            Object.keys(options.headers || {}).forEach(function(i) {
+            Object.keys(options.headers || {}).forEach(function (i) {
                 request.setValue_forHTTPHeaderField(options.headers[i], i);
             });
 
@@ -200,7 +205,7 @@ class FileManager {
                 formData.append('file', {
                     fileName: options.body.filename,
                     mimeType: options.body.mimetype,
-                    data: NSData.alloc().initWithContentsOfFile(options.filepath)
+                    data: NSData.alloc().initWithContentsOfFile(options.filepath),
                 });
             }
 
@@ -217,14 +222,11 @@ class FileManager {
             var data = formData._data;
             var boundary = formData._boundary;
 
-            request.setValue_forHTTPHeaderField(
-                "multipart/form-data; boundary=" + boundary,
-                "Content-Type"
-            );
+            request.setValue_forHTTPHeaderField('multipart/form-data; boundary=' + boundary, 'Content-Type');
 
             data.appendData(
                 NSString.alloc()
-                    .initWithString("--" + boundary + "--\r\n")
+                    .initWithString('--' + boundary + '--\r\n')
                     .dataUsingEncoding(NSUTF8StringEncoding)
             );
 
@@ -233,65 +235,77 @@ class FileManager {
             var task = NSURLSession.sharedSession().uploadTaskWithRequest_fromData_completionHandler(
                 request,
                 data,
-                __mocha__.createBlock_function(
-                    'v32@?0@"NSData"8@"NSURLResponse"16@"NSError"24',
-                    function(data, res, error) {
-                        task.progress().setCompletedUnitCount(100);
+                __mocha__.createBlock_function('v32@?0@"NSData"8@"NSURLResponse"16@"NSError"24', function (
+                    data,
+                    res,
+                    error
+                ) {
+                    task.progress().setCompletedUnitCount(100);
 
-                        if (fiber) {
-                            fiber.cleanup();
-                        }
-                        else {
-                            coscript.shouldKeepAround = false;
-                        }
-
-                        if (error) {
-                            finished = true;
-                            return reject(error);
-                        }
-
-                        return resolve(response(res, data));
+                    if (fiber) {
+                        fiber.cleanup();
+                    } else {
+                        coscript.shouldKeepAround = false;
                     }
-                )
+
+                    if (error) {
+                        finished = true;
+                        return reject(error);
+                    }
+
+                    return resolve(response(res, data));
+                })
             );
 
             task.resume();
 
-            if(overallProgress && task) {
+            if (overallProgress && task) {
                 overallProgress.addChild_withPendingUnitCount(task.progress(), 10);
             }
 
             if (fiber) {
-                fiber.onCleanup(function() {
+                fiber.onCleanup(function () {
                     if (!finished) {
                         task.cancel();
                     }
                 });
             }
-        }).then(function(response) {
-            return response.json();
-        }.bind(this)).catch(function(e) {
-            if (e.localizedDescription) {
-                console.error(e.localizedDescription);
-            }
-            else {
-                console.error(e);
-            }
+        })
+            .then(
+                function (response) {
+                    return response.json();
+                }.bind(this)
+            )
+            .catch(
+                function (e) {
+                    if (e.localizedDescription) {
+                        console.error(e.localizedDescription);
+                    } else {
+                        console.error(e);
+                    }
 
-            throw e;
-        }.bind(this));
+                    throw e;
+                }.bind(this)
+            );
     }
 
     downloadScreen(info, overallProgress) {
-        return fetch('/v1/screen/modified/' + info.id).then(function(meta) {
-            this.updateAssetStatus(meta.screen.project, meta.screen);
+        return fetch('/v1/screen/modified/' + info.id).then(
+            function (meta) {
+                this.updateAssetStatus(meta.screen.project, meta.screen);
 
-            return target.getTarget('sources').then(function(target) {
-                if (createFolder(target.path)) {
-                    return this.downloadFile({ uri: '/v1/screen/download/' + info.id, path: target.path + info.filename }, overallProgress);
-                }
-            }.bind(this));
-        }.bind(this));
+                return target.getTarget('sources').then(
+                    function (target) {
+                        if (createFolder(target.path)) {
+                            return this.downloadFile(
+                                { uri: '/v1/screen/download/' + info.id, path: target.path + info.filename },
+                                overallProgress
+                            );
+                        }
+                    }.bind(this)
+                );
+            }.bind(this)
+        );
     }
 
     downloadFile(info, overallProgress) {
@@ -302,12 +316,12 @@ class FileManager {
         let options = {
             method: 'GET',
             headers: {
-                'Authorization': 'Bearer ' + token.access_token,
-            }
+                Authorization: 'Bearer ' + token.access_token,
+            },
         };
 
         if (!uri) {
-            return Promise.reject("Missing URL");
+            return Promise.reject('Missing URL');
         }
 
         var fiber;
@@ -317,32 +331,41 @@ class FileManager {
             coscript.shouldKeepAround = true;
         }
 
-        return new Promise(function(resolve, reject) {
-            var url = NSURL.alloc().initWithString(uri);
-            var request = NSMutableURLRequest.requestWithURL(url);
-            request.setHTTPMethod("GET");
+        return new Promise(
+            function (resolve, reject) {
+                var url = NSURL.alloc().initWithString(uri);
+                var request = NSMutableURLRequest.requestWithURL(url);
+                request.setHTTPMethod('GET');
 
-            Object.keys(options.headers || {}).forEach(function(i) {
-                request.setValue_forHTTPHeaderField(options.headers[i], i);
-            });
+                Object.keys(options.headers || {}).forEach(function (i) {
+                    request.setValue_forHTTPHeaderField(options.headers[i], i);
+                });
 
-            var finished = false;
+                var finished = false;
 
-            var task = NSURLSession.sharedSession().downloadTaskWithRequest_completionHandler(
-                request,
-                __mocha__.createBlock_function(
-                    'v32@?0@"NSURL"8@"NSURLResponse"16@"NSError"24',
-                    function(location, res, error) {
+                var task = NSURLSession.sharedSession().downloadTaskWithRequest_completionHandler(
+                    request,
+                    __mocha__.createBlock_function('v32@?0@"NSURL"8@"NSURLResponse"16@"NSError"24', function (
+                        location,
+                        res,
+                        error
+                    ) {
                         let fileManager = NSFileManager.defaultManager();
                         let targetUrl = NSURL.fileURLWithPath(info.path);
 
-                        fileManager.replaceItemAtURL_withItemAtURL_backupItemName_options_resultingItemURL_error(targetUrl, location, nil, NSFileManagerItemReplacementUsingNewMetadataOnly, nil, nil);
+                        fileManager.replaceItemAtURL_withItemAtURL_backupItemName_options_resultingItemURL_error(
+                            targetUrl,
+                            location,
+                            nil,
+                            NSFileManagerItemReplacementUsingNewMetadataOnly,
+                            nil,
+                            nil
+                        );
                         task.progress().setCompletedUnitCount(100);
 
                         if (fiber) {
                             fiber.cleanup();
-                        }
-                        else {
+                        } else {
                             coscript.shouldKeepAround = false;
                         }
 
@@ -351,35 +374,35 @@ class FileManager {
                             return reject(error);
                         }
                         return resolve(targetUrl.path());
-                    }
-                )
-            );
+                    })
+                );
 
-            task.resume();
+                task.resume();
 
-            if(overallProgress && task) {
-                overallProgress.addChild_withPendingUnitCount(task.progress(), 10);
-            }
+                if (overallProgress && task) {
+                    overallProgress.addChild_withPendingUnitCount(task.progress(), 10);
+                }
 
-            if (fiber) {
-                fiber.onCleanup(function() {
-                    if (!finished) {
-                        task.cancel();
-                    }
-                });
-            }
-        }.bind(this)).catch(function(e) {
-            if (e.localizedDescription) {
-                console.error(e.localizedDescription);
-            }
-            else {
-                console.error(e);
-            }
+                if (fiber) {
+                    fiber.onCleanup(function () {
+                        if (!finished) {
+                            task.cancel();
+                        }
+                    });
+                }
+            }.bind(this)
+        ).catch(
+            function (e) {
+                if (e.localizedDescription) {
+                    console.error(e.localizedDescription);
+                } else {
+                    console.error(e);
+                }
 
-            throw e;
-        }.bind(this));
+                throw e;
+            }.bind(this)
+        );
     }
 }
 
 export default new FileManager();
-


### PR DESCRIPTION
First two commits are just prettier related so **check out f1414ea** for clarity of what I changed.

For some reason (beyond my understanding) Sketch reinstantiates (correct word?) the `filemanager` sometimes (e.g. when handling `selectionChanged` event) - which causes `filemanager` to run `clearExportFolder()`, regardless of whether `uploadFile()` has been run on those exports yet. 

Fix seems to be to remove this from `filemanager` and delete only the relevant files when the `uploadFile()` promise is resolved. Two particular `deleteFile()` calls were commented out by @brunschgi so I'd particularly like him to double check this solution.