### PR TITLE
bugfix/add-colors-to-document-scope

### DIFF
--- a/src/model/color.js
+++ b/src/model/color.js
@@ -36,29 +36,29 @@ class Color {
     }
 
     addDocumentColors(colors) {
-        let app = NSApp.delegate();
-        let doc = sketch.getDocument();
-
-        if (doc) {
-            let assets = doc.documentData().assets();
-            let mscolors = this.convertColors(colors);
-            assets.addColorAssets(mscolors);
-
-            app.refreshCurrentDocument();
-        }
+        this.addColorsToDocumentScope(colors);
     }
 
     replaceDocumentColors(colors) {
-        let app = NSApp.delegate();
-        let doc = sketch.getDocument();
+        this.addColorsToDocumentScope(colors, true);
+    }
 
-        if (doc) {
-            let assets = doc.documentData().assets();
-            let mscolors = this.convertColors(colors);
-            assets.setColorAssets([]);
-            assets.addColorAssets(mscolors);
+    addColorsToDocumentScope(colors, replaceCurrentColors = false) {
+        let selectedDocument = API.getSelectedDocument();
 
-            app.refreshCurrentDocument();
+        if (selectedDocument) {
+            if (replaceCurrentColors) {
+                selectedDocument.swatches = [];
+            }
+
+            colors.forEach((color) => {
+                selectedDocument.swatches.push(
+                    API.Swatch.from({
+                        name: color.name,
+                        color: color.css_value_hex,
+                    })
+                );
+            });
         }
     }
 

--- a/src/model/color.js
+++ b/src/model/color.js
@@ -36,11 +36,19 @@ class Color {
     }
 
     addDocumentColors(colors) {
-        this.addColorsToDocumentScope(colors);
+        if (this.getSketchVersion() >= '69') {
+            this.addColorsToDocumentScope(colors);
+        } else {
+            this.addColorsToDocumentScopeLegacy(colors);
+        }
     }
 
     replaceDocumentColors(colors) {
-        this.addColorsToDocumentScope(colors, true);
+        if (this.getSketchVersion() >= '69') {
+            this.addColorsToDocumentScope(colors, true);
+        } else {
+            this.addColorsToDocumentScopeLegacy(colors, true);
+        }
     }
 
     addColorsToDocumentScope(colors, replaceCurrentColors = false) {
@@ -58,6 +66,23 @@ class Color {
                         color: color.css_value_hex,
                     })
                 );
+            });
+        }
+    }
+
+    /**
+     * @deprecated Should only be used in sketch version 68 and older! Use 'addColorsToDocumentScope' instead.
+     */
+    addColorsToDocumentScopeLegacy(colors, replaceCurrentColors = false) {
+        let selectedDocument = API.getSelectedDocument();
+
+        if (selectedDocument) {
+            if (replaceCurrentColors) {
+                selectedDocument.colors = [];
+            }
+
+            this.convertColors(colors).forEach((convertedColor) => {
+                selectedDocument.colors.push(convertedColor);
             });
         }
     }
@@ -158,6 +183,10 @@ class Color {
                 }
             }.bind(this)
         );
+    }
+
+    getSketchVersion() {
+        return API.Settings.version.sketch;
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug which prevents colors to be applied to the document scope (Fixes [clarify #3827](https://github.com/Frontify/clarify/issues/3827)) for users using Sketch 69 or newer.
