### PR TITLE
Removed macOS native code which broke the sketch plugin in newer macOS versions

### DIFF
--- a/src/model/asset.js
+++ b/src/model/asset.js
@@ -70,7 +70,6 @@ class Asset {
                     imageLayer.frame.height = imageSize.height;
 
                     let imageData = imageLayer.image;
-                    let app = NSApp.delegate();
                     let applied = false;
 
                     jsdoc.selectedLayers.forEach(
@@ -118,15 +117,11 @@ class Asset {
                         jsdoc.centerOnLayer(imageLayer);
                         jsdoc.sketchObject.eventHandlerManager().currentHandler().zoomToSelection();
                     }
-
-                    app.refreshCurrentDocument();
                 }
             } else {
                 fetch(url, { cdn: true })
                     .then(
                         function (blob) {
-                            let app = NSApp.delegate();
-
                             let svg = NSString.stringWithString(blob);
                             let svgData = svg.dataUsingEncoding(NSUTF8StringEncoding);
 
@@ -157,8 +152,6 @@ class Asset {
                             jsLayer.selected = true;
                             jsdoc.centerOnLayer(jsLayer);
                             jsdoc.sketchObject.eventHandlerManager().currentHandler().zoomToSelection();
-
-                            app.refreshCurrentDocument();
                         }.bind(this)
                     )
                     .catch(

--- a/src/model/sketch.js
+++ b/src/model/sketch.js
@@ -1,8 +1,7 @@
 import user from './user';
 
 class Sketch {
-    constructor() {
-    }
+    constructor() {}
 
     getViewData() {
         let data = {};
@@ -11,8 +10,7 @@ class Sketch {
             data.url = require('../assets/views/main.html');
             data.width = 480;
             data.height = 600;
-        }
-        else {
+        } else {
             data.url = require('../assets/views/login.html');
             data.width = 360;
             data.height = 530;
@@ -24,24 +22,23 @@ class Sketch {
     resize(win) {
         let viewData = this.getViewData();
         win.setSize(viewData.width, viewData.height, true);
-
     }
 
     // generic search functions (from https://medium.com/sketch-app-sources/sketch-plugin-snippets-for-plugin-developers-e9e1d2ab6827)
     findLayers(predicate, container, layerType, doc) {
         doc = doc || this.getDocument();
-        if(!doc) {
+        if (!doc) {
             return NSArray.array();
         }
 
         let scope;
         switch (layerType) {
-            case MSPage :
+            case MSPage:
                 scope = doc.pages();
                 return scope.filteredArrayUsingPredicate(predicate);
                 break;
 
-            case MSArtboardGroup :
+            case MSArtboardGroup:
                 if (typeof container !== 'undefined' && container != nil) {
                     if (container.className == 'MSPage') {
                         scope = container.artboards();
@@ -50,26 +47,32 @@ class Sketch {
                 } else {
                     // search all pages
                     let filteredArray = NSArray.array();
-                    let loopPages = doc.pages().objectEnumerator(), page;
-                    while (page = loopPages.nextObject()) {
+                    let loopPages = doc.pages().objectEnumerator(),
+                        page;
+                    while ((page = loopPages.nextObject())) {
                         scope = page.artboards();
-                        filteredArray = filteredArray.arrayByAddingObjectsFromArray(scope.filteredArrayUsingPredicate(predicate));
+                        filteredArray = filteredArray.arrayByAddingObjectsFromArray(
+                            scope.filteredArrayUsingPredicate(predicate)
+                        );
                     }
                     return filteredArray;
                 }
                 break;
 
-            default :
+            default:
                 if (typeof container !== 'undefined' && container != nil) {
                     scope = container.children();
                     return scope.filteredArrayUsingPredicate(predicate);
                 } else {
                     // search all pages
                     let filteredArray = NSArray.array();
-                    let loopPages = doc.pages().objectEnumerator(), page;
-                    while (page = loopPages.nextObject()) {
+                    let loopPages = doc.pages().objectEnumerator(),
+                        page;
+                    while ((page = loopPages.nextObject())) {
                         scope = page.children();
-                        filteredArray = filteredArray.arrayByAddingObjectsFromArray(scope.filteredArrayUsingPredicate(predicate));
+                        filteredArray = filteredArray.arrayByAddingObjectsFromArray(
+                            scope.filteredArrayUsingPredicate(predicate)
+                        );
                     }
                     return filteredArray;
                 }
@@ -84,11 +87,12 @@ class Sketch {
 
     getSelection() {
         let doc = this.getDocument();
-        if(!doc) {
+
+        if (!doc) {
             return NSArray.array();
         }
 
-        return doc.selectedLayers().layers();
+        return doc.selectedLayers();
     }
 
     getDocument() {
@@ -97,4 +101,3 @@ class Sketch {
 }
 
 export default new Sketch();
-

--- a/src/model/typography.js
+++ b/src/model/typography.js
@@ -242,7 +242,6 @@ class Typography {
     }
 
     addFontStyles(fontStyles) {
-        let app = NSApp.delegate();
         let doc = sketch.getDocument();
         if (doc) {
             let msstyles = this.convertFontStyles(fontStyles);
@@ -259,8 +258,6 @@ class Typography {
                     this.updateLayersWithStyle(sharedStyles.objects(), msstyle.name(), msstyle.style());
                 }.bind(this)
             );
-
-            app.refreshCurrentDocument();
         }
     }
 


### PR DESCRIPTION
This PR fixes some bugs which made the plugin crash when choosing brand assets.

- Additionally removed fallbacks for Sketch version 68 and older.