### PR TITLE
Add support for nested symbol overrides with option set to 'no symbol'

### DIFF
--- a/src/model/artboard.js
+++ b/src/model/artboard.js
@@ -337,6 +337,12 @@ class Artboard {
         return detachedGroupExport;
     }
 
+    layerIsDetachableSymbolInstance(layer) {
+        // SymbolInstance with empty layer.symbolId is used if symbol overrides
+        // are defined and override property is set to 'no symbol' (Sketch 88)
+        return layer.type === 'SymbolInstance' && !!layer.symbolId;
+    }
+
     /**
      * The recursion is done manually, so we can add meta to separated symbols before we detach them.
      * In this way, we can later determine that it was a symbol.
@@ -353,8 +359,7 @@ class Artboard {
             });
 
             return;
-        } else if (layer.type !== 'SymbolInstance') {
-            /* if it's not a symbol, there's nothing to do */
+        } else if (this.layerIsDetachableSymbolInstance(layer) === false) {
             return;
         }
 


### PR DESCRIPTION
### Test data
[testdata.zip](https://github.com/Frontify/sketch/files/8822214/testdata.zip)

### How to reproduce
- See two cases in testdata.zip
- Nested symbols using overrides to define another symbol
- Set override symbol to 'No Symbol' 

![with symbol](https://user-images.githubusercontent.com/3276065/171591831-c5262e1b-28e1-4f09-b71a-4ac81e5ca6b3.png)
![without symbol](https://user-images.githubusercontent.com/3276065/171591846-a25f30f6-a534-44d8-9c5c-b2a680c1c016.png)


### Failure
- export crashes, copy of detached symbol remains (Folder with the name '[export copy] ...'

### Fix
![Screenshot 2022-06-02 at 09 57 04](https://user-images.githubusercontent.com/3276065/171591965-9b0db92d-0d9b-42a9-a662-330075f06d29.png)

Checking if the layer of type symbolInstance has a valid symbolId 

