### PR TITLE
increase the limit of displayed assets to 999

### DIFF
--- a/src/assets/patterns/molecules/mediachooser/js/mediachooser.js
+++ b/src/assets/patterns/molecules/mediachooser/js/mediachooser.js
@@ -102,7 +102,7 @@ Tc.Module.MediaChooser = Tc.Module.extend({
 
     onTabSwitched(data) {
         if (data.id === this.type) {
-            this.$assets.html('');
+            this.$assets.html(window.tpl.loaderspinner());
             window.postMessage('showLibrary', this.type);
         }
     }

--- a/src/model/asset.js
+++ b/src/model/asset.js
@@ -6,6 +6,8 @@ import { isWebviewPresent, sendToWebview } from 'sketch-module-web-view/remote';
 let API = require('sketch');
 let DOM = require('sketch/dom');
 
+const MAX_ASSETS_TO_REQUEST_FOR_LIBRARY = 999;
+
 class Asset {
     constructor() {}
 
@@ -13,15 +15,16 @@ class Asset {
         return target.getSelectedAssetSourceForType(type).then(
             function (assetSource) {
                 // search assets
+                const cleanedQuery = query === 'q=' ? '' : query; // do not use query if empty
                 let url = '/v1/assets/search/';
                 if (assetSource.implicit_access) {
-                    url += assetSource.connected_document_id + '?' + query;
+                    url += assetSource.connected_document_id + '?' + cleanedQuery;
                 } else {
-                    url += '?project_id=' + assetSource.id + '&' + query;
+                    url += '?project_id=' + assetSource.id + '&' + cleanedQuery;
                 }
 
-                if (query === '') {
-                    url += '&limit=100';
+                if (cleanedQuery === '') {
+                    url += `&limit=${MAX_ASSETS_TO_REQUEST_FOR_LIBRARY}`;
                 }
 
                 return fetch(url).then(

--- a/src/model/project.js
+++ b/src/model/project.js
@@ -2,11 +2,13 @@ import fetch from '../helpers/fetch'
 import target from './target';
 import { isWebviewPresent, sendToWebview } from 'sketch-module-web-view/remote'
 
+const MAX_PROJECTS_TO_REQUEST = 999
+
 class Project {
     constructor() {}
 
     getProjects() {
-        return fetch('/v1/brand/list/?project_limit=999').then(
+        return fetch(`/v1/brand/list/?project_limit=${MAX_PROJECTS_TO_REQUEST}`).then(
             function (data) {
                 return data.brands;
             }.bind(this)


### PR DESCRIPTION
fixes https://app.clickup.com/t/263hujx
Increasing the limit does not seem to have an impact on performance, except the GET requests taking a bit longer for libraries with a large number of assets.
I also added a message that is shown in case there are more assets available than 999. It is in a separate branch, because I need feedback from design (probably Jamie) on that and I didn't want it to block this bugfix