### PR TITLE
feat: Fix "Upload" functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@babel/runtime": "7.20.7",
                 "@skpm/builder": "0.8.0",
                 "@skpm/child_process": "0.4.2",
+                "@skpm/fs": "^0.2.6",
                 "mocha-js-delegate": "0.2.0",
                 "sketch-module-web-view": "3.5.1"
             },
@@ -1779,6 +1780,11 @@
             "engines": {
                 "node": ">= 4.3 < 5.0.0 || >= 5.10"
             }
+        },
+        "node_modules/@skpm/fs": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@skpm/fs/-/fs-0.2.6.tgz",
+            "integrity": "sha512-8epNXmTl7ZiYshpi0MnI/QLQ2uvlc46K8yCD5RtVa0reXU5K6xfMuTdpY6G5dqlzdhIY5WhVD+1K4V6C22ytXQ=="
         },
         "node_modules/@skpm/internal-utils": {
             "version": "0.1.16",
@@ -8137,6 +8143,11 @@
                 "loader-utils": "1.4.2",
                 "schema-utils": "^0.4.5"
             }
+        },
+        "@skpm/fs": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@skpm/fs/-/fs-0.2.6.tgz",
+            "integrity": "sha512-8epNXmTl7ZiYshpi0MnI/QLQ2uvlc46K8yCD5RtVa0reXU5K6xfMuTdpY6G5dqlzdhIY5WhVD+1K4V6C22ytXQ=="
         },
         "@skpm/internal-utils": {
             "version": "0.1.16",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "@babel/runtime": "7.20.7",
         "@skpm/builder": "0.8.0",
         "@skpm/child_process": "0.4.2",
+        "@skpm/fs": "^0.2.6",
         "mocha-js-delegate": "0.2.0",
         "sketch-module-web-view": "3.5.1"
     },

--- a/src/model/artboard.js
+++ b/src/model/artboard.js
@@ -143,22 +143,20 @@ class Artboard {
             function (resolve) {
                 let files = [];
                 let jsdocument = DOM.Document.fromNative(doc);
-                let jsartboard = jsdocument.getLayerWithID(artboard.id_external); // DOM Artboard
-                let msartboard = jsartboard.sketchObject;
+                let jsartboard = jsdocument.getLayerWithID(artboard.id_external);
 
-                // Export artboard image -> traditional MSExportRequest for better naming control
-                let imageFormat = MSExportFormat.alloc().init();
-                imageFormat.setFileFormat('png');
-                imageFormat.setScale(this.pixelRatio); // @2x
+                // NB! Compared to the old Objective-C API, the new Sketch JavaScript API exports the file with a slightly different name:
+                // old - 'name of the artboard.png'
+                // new - 'name of the artboard@2x.png'
+                DOM.export(jsartboard, {
+                    formats: 'png',
+                    output: filemanager.getExportPath(),
+                    overwriting: true,
+                    scales: `${this.pixelRatio}x`,
+                    trimmed: false,
+                });
 
-                let path = filemanager.getExportPath() + artboard.name + '.png';
-                let exportRequest = MSExportRequest.exportRequestsFromExportableLayer_exportFormats_useIDForName(
-                    msartboard,
-                    [imageFormat],
-                    true
-                ).firstObject();
-
-                doc.saveArtboardOrSlice_toFile(exportRequest, path);
+                let path = filemanager.getExportPath() + artboard.name + '@' + this.pixelRatio + 'x.png';
 
                 files.push({
                     name: artboard.name,

--- a/src/model/artboard.js
+++ b/src/model/artboard.js
@@ -142,8 +142,9 @@ class Artboard {
         return new Promise(
             function (resolve) {
                 let files = [];
-                let predicate = NSPredicate.predicateWithFormat('objectID == %@', artboard.id_external);
-                let msartboard = sketch.findFirstLayer(predicate, nil, MSArtboardGroup, doc);
+                let jsdocument = DOM.Document.fromNative(doc);
+                let jsartboard = jsdocument.getLayerWithID(artboard.id_external); // DOM Artboard
+                let msartboard = jsartboard.sketchObject;
 
                 // Export artboard image -> traditional MSExportRequest for better naming control
                 let imageFormat = MSExportFormat.alloc().init();
@@ -170,7 +171,6 @@ class Artboard {
                 });
 
                 // Export artboard structure -> via JS API as its not possible to export JSON with MSExportRequest
-                let jsartboard = DOM.Artboard.fromNative(msartboard);
 
                 // Export the artboard's data first to preprocess and optimize data
                 let artboardExport = DOM.export(jsartboard, {

--- a/src/model/artboard.js
+++ b/src/model/artboard.js
@@ -7,6 +7,7 @@ import target from './target';
 import filemanager from './filemanager';
 import asset from './asset';
 import { isWebviewPresent, sendToWebview } from 'sketch-module-web-view/remote';
+import fs from '@skpm/fs';
 
 let API = require('sketch');
 let DOM = require('sketch/dom');
@@ -148,15 +149,18 @@ class Artboard {
                 // NB! Compared to the old Objective-C API, the new Sketch JavaScript API exports the file with a slightly different name:
                 // old - 'name of the artboard.png'
                 // new - 'name of the artboard@2x.png'
-                DOM.export(jsartboard, {
+                const buffer = DOM.export(jsartboard, {
                     formats: 'png',
-                    output: filemanager.getExportPath(),
-                    overwriting: true,
+                    output: false, // Export to buffer, not file
                     scales: `${this.pixelRatio}x`,
                     trimmed: false,
                 });
 
-                let path = filemanager.getExportPath() + artboard.name + '@' + this.pixelRatio + 'x.png';
+                // Trim whitespace and replace problematic characters (and spaces) with underscores
+                const safeName = artboard.name.trim().replace(/[<>:"/\\|?*\s]+/g, '_');
+                const path = filemanager.getExportPath() + safeName + '@' + this.pixelRatio + 'x.png';
+                fs.writeFileSync(path, buffer);
+
 
                 files.push({
                     name: artboard.name,

--- a/src/model/filemanager.js
+++ b/src/model/filemanager.js
@@ -5,6 +5,7 @@ import createFolder from '../helpers/createFolder';
 import target from './target';
 import sketch from './sketch';
 import FormData from 'sketch-polyfill-fetch/lib/form-data';
+import fs from '@skpm/fs';
 import extend from '../helpers/extend';
 import response from '../helpers/response';
 
@@ -210,10 +211,12 @@ class FileManager {
 
             // Form encoded params
             if (options.filepath) {
+                const buffer = fs.readFileSync(options.filepath);
+                
                 formData.append('file', {
                     fileName: options.body.filename,
                     mimeType: options.body.mimetype,
-                    data: NSData.alloc().initWithContentsOfFile(options.filepath),
+                    data: buffer,
                 });
             }
 

--- a/src/model/sketch.js
+++ b/src/model/sketch.js
@@ -80,11 +80,6 @@ class Sketch {
         return NSArray.array(); // Return an empty array if no matches were found
     }
 
-    findFirstLayer(predicate, container, layerType, doc) {
-        let filteredArray = this.findLayers(predicate, container, layerType, doc);
-        return filteredArray.firstObject();
-    }
-
     getSelection() {
         let doc = this.getDocument();
 


### PR DESCRIPTION
With the recent release of Sketch Beta, our plugin no longer works. There are likely a number of reasons, incl. heavy reliance on the private Objective-C APIs which are no longer guaranteed to work or even exist in Sketch Beta, and therefore need to be replaced with Sketch's JavaScript APIs. The current PR attempts to tackle this, so the plugin would stay compatible with both earlier and newer versions of Sketch.

Fixes to the "Upload" functionality by commit:
- 5cf897c82c6c8bfab39145a65cc520a06f540237 - Removing the reference to `MSArtboardGroup` which is no longer exposed and therefore throws `ReferenceError: Can't find variable: MSArtboardGroup`. Getting the needed `jsartboard` and `msartboard` from `sketch/dom` instead.
- fc05738b640cd4a3aabbabd2fe0c54ab191f4820 - Replacing the usages of legacy `MSExportFormat`, `MSExportRequest` and `saveArtboardOrSlice_toFile` with `DOM.export`. This has a slight effect on the name of the exported file - `name of the artboard.png` becomes `name of the artboard@2x.png`. Next commits will likely address this as well.
- 570cfa8b843333a51b57494f40431a08c62fccd8 - Replacing the usage of legacy `MSExportFormat` for layer.exportFormats with `DOM.export`. Previously the exported filename also included a timestamp. With `DOM.export` it's generated automatically and not returned. The `path` value we previously assembled is still used in files.push. For now, we predict it using the export options ('1x' scale is the only one that's omitted).
- 84bbf5ed54b4df7eda1aec7a9e20c87322e8f70e - Replacing the file path with buffer for upload and export, using `@skpm/fs` (a Sketch wrapper for nodejs fs). The `formData` polyfill used for the upload had stopped supporting the native `NSData` object, and led to the "unknown value type" error when trying to serialize it. Another interesting issue came from having switched to DOM.export - the file that is temporarily stored on disk had unexpected spaces in its path: instead of `.../T/sketch-frontify/Screenshot/iPhone 6.7"@2x.png` it was `.../T/sketch-frontify/Screenshot / iPhone 6.7"@2x.png`, and as a result the export/upload failed with `Error: ENOENT: no such file or directory`. This was due to how the artboard itself was named in Sketch - `Screenshot / iPhone 6.7"`. When uploading to Frontify, the `/` in the file name was previously treated as a folder separator, so I kept the existing behaviour and in the case of the above example the `iPhone...` file would still be uploaded into the `Screenshot` folder. To make the error go away, whitespace had to be trimmed for the temporary storing of the file on disk, and I've also replaced potentially problematic characters (`<`, `>`, `:`, `"`, `/`, `\`, `|`, `?`, `*`) and spaces with `_`, just to be on the safe side.

ClickUp ticket ID: CU-86990xpjz