### PR TITLE
chore(build): Drop babel plugins

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-    "plugins": ["@babel/plugin-transform-runtime","@babel/plugin-syntax-async-generators"]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,6 @@
                 "sketch-module-web-view": "^3.5.3"
             },
             "devDependencies": {
-                "@babel/plugin-syntax-async-generators": "^7.8.4",
-                "@babel/plugin-transform-async-generator-functions": "^7.29.0",
-                "@babel/plugin-transform-export-namespace-from": "^7.27.1",
-                "@babel/plugin-transform-object-rest-spread": "^7.28.6",
-                "@babel/plugin-transform-runtime": "^7.19.6",
                 "@mcler/webpack-concat-plugin": "^4.1.6",
                 "@skpm/builder": "^1.0.0",
                 "@skpm/extract-loader": "2.0.3",
@@ -491,19 +486,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-async-generators": {
-            "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"

--- a/package.json
+++ b/package.json
@@ -22,11 +22,6 @@
         "postinstall": "npm run build && skpm-link"
     },
     "devDependencies": {
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/plugin-transform-async-generator-functions": "^7.29.0",
-        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
-        "@babel/plugin-transform-object-rest-spread": "^7.28.6",
-        "@babel/plugin-transform-runtime": "^7.19.6",
         "@skpm/builder": "^1.0.0",
         "@skpm/extract-loader": "2.0.3",
         "copy-webpack-plugin": "^14.0.0",


### PR DESCRIPTION
They're now included in the skpm builder. 
More details [here](https://github.com/Frontify/sketch/pull/47#discussion_r3173608688).
