### PR TITLE
fix: frozen UI state after login/logout

### DIFF
--- a/src/model/sketch.js
+++ b/src/model/sketch.js
@@ -4,16 +4,15 @@ class Sketch {
     constructor() {}
 
     getViewData() {
-        let data = {};
+        let data = {
+            width: 480,
+            height: 600,
+        };
 
         if (user.isAuthenticated()) {
             data.url = require('../assets/views/main.html');
-            data.width = 480;
-            data.height = 600;
         } else {
             data.url = require('../assets/views/login.html');
-            data.width = 360;
-            data.height = 530;
         }
 
         return data;

--- a/src/windows/main.js
+++ b/src/windows/main.js
@@ -47,7 +47,7 @@ export default function (context, view) {
         'ready-to-show',
         function () {
             win.show();
-        }.bind(this)
+        }.bind(this),
     );
 
     webview.on('cancelOauthFlow', () => {
@@ -66,9 +66,9 @@ export default function (context, view) {
                 domain: domain,
             }).then(
                 function () {
-                    win.close();
-                    runCommand(context);
-                }.bind(this)
+                    sketch.resize(win);
+                    webview.loadURL(sketch.getViewData().url);
+                }.bind(this),
             );
         });
     });
@@ -85,30 +85,30 @@ export default function (context, view) {
                     webview.executeJavaScript('switchTab("' + view + '")');
                 }, 200);
             }
-        }.bind(this)
+        }.bind(this),
     );
 
     webview.on(
         'did-fail-load',
         function (err) {
             console.log('did-fail-load', err);
-        }.bind(this)
+        }.bind(this),
     );
 
     win.on(
         'close',
         function () {
             threadDictionary.removeObjectForKey('frontifywindow');
-        }.bind(this)
+        }.bind(this),
     );
 
     // Handlers called from webview
     webview.on('logout', function () {
         user.logout().then(
             function () {
-                win.close();
-                runCommand(context);
-            }.bind(this)
+                sketch.resize(win);
+                webview.loadURL(sketch.getViewData().url);
+            }.bind(this),
         );
     });
 
@@ -135,7 +135,7 @@ export default function (context, view) {
         artboard.uploadArtboards(data).then(
             function () {
                 webview.executeJavaScript('artboardsUploaded()');
-            }.bind(this)
+            }.bind(this),
         );
     });
 
@@ -146,18 +146,18 @@ export default function (context, view) {
                     let selected = data.sources.find(
                         function (source) {
                             return source.id == assetSourceId;
-                        }.bind(this)
+                        }.bind(this),
                     );
 
                     if (selected) {
                         target.switchAssetSourceForType(type, selected).then(
                             function () {
                                 webview.executeJavaScript('refresh()');
-                            }.bind(this)
+                            }.bind(this),
                         );
                     }
                 }
-            }.bind(this)
+            }.bind(this),
         );
     });
 
@@ -168,7 +168,7 @@ export default function (context, view) {
             target.getDomain().then(
                 function (data) {
                     NSWorkspace.sharedWorkspace().openURL(NSURL.URLWithString(data + url));
-                }.bind(this)
+                }.bind(this),
             );
         }
     });
@@ -179,7 +179,7 @@ export default function (context, view) {
                 if (createFolder(data.path)) {
                     NSWorkspace.sharedWorkspace().openFile(data.path);
                 }
-            }.bind(this)
+            }.bind(this),
         );
     });
 
@@ -192,7 +192,7 @@ export default function (context, view) {
             function () {
                 target.showTarget();
                 webview.executeJavaScript('refresh()');
-            }.bind(this)
+            }.bind(this),
         );
     });
 
@@ -205,13 +205,13 @@ export default function (context, view) {
             target.updateTarget({ set: set }).then(
                 function () {
                     artboard.showArtboards();
-                }.bind(this)
+                }.bind(this),
             );
         } else if (view == 'sources') {
             target.updateTarget({ set_sources: set }).then(
                 function () {
                     source.showSources();
-                }.bind(this)
+                }.bind(this),
             );
         }
     });
@@ -220,7 +220,7 @@ export default function (context, view) {
         project.addFolder(name, set).then(
             function () {
                 project.showFolderChooser(set, view);
-            }.bind(this)
+            }.bind(this),
         );
     });
 
@@ -315,7 +315,7 @@ export default function (context, view) {
                     webview.executeJavaScript('showLibrarySearch("' + type + '")');
                     asset.search(type, '');
                 }
-            }.bind(this)
+            }.bind(this),
         );
     });
 


### PR DESCRIPTION
Until now, we closed the window after a login or logout and opened a
fresh one via `runCommand(context)`.
`sketch-module-web-view` no longer destroys (no idea when this changed)
the webview on `win.close()`.
This means trying to open a new window via `win.close()` will give an
error as it reuses the existing window.
This left the UI stuck in the current view, even though the logout/login
was successful.
Instead of re-running the main function again, we just load the new view into
the existing webview after the login/logout finished.
